### PR TITLE
Proxy via background

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -1,0 +1,28 @@
+var port = browser.runtime.connectNative("foxycli");
+console.log('CONNECT NATIVE CALLED');
+
+var mute_state = false;
+
+port.onMessage.addListener((response) => {
+  if (mute_state) {
+    return;
+  }
+  if (response.cmd == "OPEN_TAB") {
+    // We handle this command in the background page and do not forward it to the panel
+    browser.tabs.create({});
+    return;
+  }
+  browser.runtime.sendMessage({
+    foxycli: response
+  });
+});
+
+browser.runtime.onMessage.addListener((message) => {
+  if (message.type == "port.postMessage") {
+    port.postMessage(message.body);
+  } else if (message.type == "set_mute_state") {
+    mute_state = message.value;
+  } else {
+    console.error("Got unknown message:", JSON.stringify(message));
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,12 @@
       "default_icon": "icons/Foxy-SF.svg"
     },
 
+    "background": {
+      "scripts": [
+        "background/background.js"
+      ]
+    },
+
     "permissions": ["nativeMessaging",  "bookmarks", "tabs", "activeTab", "<all_urls>"],
 
     "commands": {


### PR DESCRIPTION
This moves the port into a background page. This doesn't affect things much, because messages are usually just sent over to the panel. But it will make different UIs easier in the future.

This also moves the mute flag into the background page, so that the background page can ignore messages when Foxy is muted.

An OPEN_TAB command is added, mostly as a demonstration. foxycli has to be updated to actually send such a command.